### PR TITLE
Some fixes to the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,14 @@ Combining profiler events across hosts yields a picture of the distributed syste
 
                  ; Flatten function times across hosts, updating every 60s.
                  #".*profiler fn .+"
-                 (by :service
-                     (coalesce 60
-                               (smap folds/sum
-                                        (with {:host nil :ttl 120} index)))))))
+                 (pipe - (by :service
+                             (coalesce 60
+                                       (smap folds/sum
+                                             (with {:host nil :ttl 120} -))))
+                       ; And index the top 10.
+                       (top 10 :metric
+                            index
+                            (with :state "expired" index))))))
 
 ; I usually have a top-level splitp to route events to various subsystems.
 (let [index (index)]


### PR DESCRIPTION
As written, the example basically doesn't work for me. Here is a copy-paste of my thought process from IRC:

[2:56pm] gregorstocks: ok, it seems to be working if I a) replace smap with combine and b) replace (top ...) with index. i'm not sure what the right way to handle top here is but it's not that, it doesn't interact with (by :service ...) properly
[2:57pm] gregorstocks: that does cause logspew about combine being deprecated, but neither smap nor sreduce seems appropriate here and I can live with logspew
[2:58pm] gregorstocks: that's only the "flatten function times across hosts" bit, I don't care about the profiler rate so I just cut that bit out but I'm guessing that wants combine instead of smap too
[3:00pm] gregorstocks: though I might be missing something, since the docs seem convinced that smap is a general-purpose replacement for combine but that's definitely not true as I understand those functions
[3:01pm] gregorstocks: for example the docs for fixed-event-window do this: `(fixed-event-window 5 (smap folds/mean index))` which seems to me like it shouldn't work
[3:14pm] gregorstocks: ok i think ive got it fully working and this is FANTASTIC

I'm still seeing some issues on my install (I get about 8 seconds of everything great, and then 2 seconds in which the most expensive parts disappear, then back to everything great again, etc), but it's much better this way than it was before.
