### PR TITLE
Fix an ambiguous Thread/sleep call on JDK 19

### DIFF
--- a/src/riemann/jvm_profiler/stack.clj
+++ b/src/riemann/jvm_profiler/stack.clj
@@ -174,6 +174,7 @@
                           (/ 1e6 target-load)
                           (max 1)
                           (min 1000)
+                          (long)
                           (Thread/sleep))
                       t0)
                     (catch Exception e


### PR DESCRIPTION
Java 19 has introduced [Thread.sleep(Duration)][1] that makes one of the calls to Thread/sleep ambiguous. This has resulted in a compile time warning:

    Reflection warning, riemann/jvm_profiler/stack.clj:177:27 - call
    to static method sleep on java.lang.Thread can't be resolved
    (argument types: java.lang.Object).

as well as a runtime error "No matching method sleep found."

This patch fixes it by explicitly coercing the double value to a long, thus making the Thread/sleep call unambiguous.

Hat tip to @mvitz for helping me diagnose this problem.

[1]: https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/lang/Thread.html#sleep%28java.time.Duration%29